### PR TITLE
fix WebDAV Unicode path encoding

### DIFF
--- a/src/network/remotePath.ts
+++ b/src/network/remotePath.ts
@@ -81,10 +81,24 @@ export function hrefToRelative(baseUrl: string, base: string, href: string): str
   return fromRemotePath(base, fromRoot);
 }
 
-/** Build a WebDAV URL from a files-root-relative path (keep slashes, URL-encode each segment). */
+/**
+ * Build a WebDAV URL from a files-root-relative path.
+ *
+ * Obsidian's request layer performs the UTF-8 URL encoding when it sends the request. Encoding
+ * non-ASCII characters here as well can therefore turn e.g. `中文` into the literal filename
+ * `%E4%B8%AD%E6%96%87` on Nextcloud (the `%` is escaped a second time by the request layer).
+ * Keep non-ASCII characters intact, while still escaping ASCII characters that have structural
+ * meaning in a URL (`#`, `?`, spaces, `%`, ...). Slashes remain path separators.
+ */
 export function encodeRemoteUrl(baseUrl: string, remotePath: string): string {
   if (!remotePath) return baseUrl;
-  return `${baseUrl}/${encodeURIComponent(remotePath).replace(/%2F/g, '/')}`;
+  const encodedPath = remotePath
+    .split('/')
+    .map((segment) => Array.from(segment, (char) =>
+      (char.codePointAt(0) ?? 0) > 0x7f ? char : encodeURIComponent(char),
+    ).join(''))
+    .join('/');
+  return `${baseUrl}/${encodedPath}`;
 }
 
 /**

--- a/tests/a-no-nextcloud/network/remotePath.test.ts
+++ b/tests/a-no-nextcloud/network/remotePath.test.ts
@@ -3,6 +3,7 @@ import {
   fromRemotePath,
   toRemotePath,
   isSafeVaultRelativePath,
+  encodeRemoteUrl,
 } from '../../../src/network/remotePath';
 
 describe('hrefToRelative', () => {
@@ -78,5 +79,23 @@ describe('fromRemotePath (traversal hardening)', () => {
   });
   it('returns null for traversal when no base is configured', () => {
     expect(fromRemotePath('', '../secret.md')).toBeNull();
+  });
+});
+
+describe('encodeRemoteUrl', () => {
+  const baseUrl = 'https://example.com/remote.php/dav/files/alice';
+
+  it('leaves Chinese path characters for the Obsidian request layer to encode once', () => {
+    expect(encodeRemoteUrl(baseUrl, '中文仓库/日记.md'))
+      .toBe(`${baseUrl}/中文仓库/日记.md`);
+  });
+
+  it('preserves Unicode while escaping ASCII URL delimiters inside file names', () => {
+    expect(encodeRemoteUrl(baseUrl, '资料 目录/问题#1?.md'))
+      .toBe(`${baseUrl}/资料%20目录/问题%231%3F.md`);
+  });
+
+  it('keeps path separators instead of escaping them', () => {
+    expect(encodeRemoteUrl(baseUrl, 'a/b/c.md')).toBe(`${baseUrl}/a/b/c.md`);
   });
 });


### PR DESCRIPTION
## Summary

Fixes WebDAV uploads where folders and files containing Chinese, Japanese, emoji, or other non-ASCII characters could be created on Nextcloud using their percent-encoded UTF-8 representation as the literal name.

For example:

- Expected: `中文目录/日记.md`
- Actual: `%E4%B8%AD%E6%96%87%E7%9B%AE%E5%BD%95/%E6%97%A5%E8%AE%B0.md`

## Root cause

`encodeRemoteUrl()` encoded non-ASCII path characters before passing the URL to Obsidian's request layer. On affected platforms, the request layer encoded the percent signs again, causing Nextcloud to receive the percent-encoded text as the actual remote filename.

## Changes

- Leave non-ASCII path characters intact so Obsidian encodes them exactly once.
- Continue escaping ASCII characters with structural meaning in URLs, including spaces, `#`, `?`, and `%`.
- Preserve `/` as the separator between WebDAV path segments.
- Add regression tests covering Chinese folder and file names, URL-reserved characters, and nested paths.

Because URL construction is shared, the fix applies to regular uploads, directory creation, downloads, moves, and chunked uploads.

## Validation

- ESLint passed.
- TypeScript type checking passed.
- WebDAV path tests passed: 21/21.